### PR TITLE
fix: move seeker on trim

### DIFF
--- a/src/routes/[id]/components/seeker.svelte
+++ b/src/routes/[id]/components/seeker.svelte
@@ -39,10 +39,15 @@
 	}
 
 	onMount(() => {
+		const unsubscribe = edits.subscribe(({ startAt, endAt }) => {
+			$videoStatus.currentTime = Math.max(startAt, Math.min($videoStatus.currentTime, endAt));
+		});
+
 		document.addEventListener('mousemove', (e) => handleSeeking(e));
 		document.addEventListener('mouseup', handleSeekEnd);
 
 		return () => {
+			unsubscribe();
 			document.removeEventListener('mousemove', handleSeeking);
 			document.removeEventListener('mouseup', handleSeekEnd);
 		};


### PR DESCRIPTION
when user trim video, seeker shouldn't be able to start before trim start nor end after trim end